### PR TITLE
Reduce the number of open imports

### DIFF
--- a/library/Language/Ninja/AST/Rule.hs
+++ b/library/Language/Ninja/AST/Rule.hs
@@ -47,9 +47,9 @@ module Language.Ninja.AST.Rule
   , ResponseFile, makeResponseFile, responseFilePath, responseFileContent
   ) where
 
-import           Language.Ninja.AST.Pool
-import           Language.Ninja.Misc.Command
-import           Language.Ninja.Misc.Path
+import           Language.Ninja.AST.Pool     (PoolName, poolNameDefault)
+import           Language.Ninja.Misc.Command (Command)
+import           Language.Ninja.Misc.Path    (Path)
 
 import           Data.Text                   (Text)
 import qualified Data.Text                   as T
@@ -59,10 +59,10 @@ import           Data.Aeson                  as Aeson
 import           Data.Hashable               (Hashable (..))
 import           GHC.Generics                (Generic)
 
-import           Control.Lens.Lens
-import           Control.Lens.Prism
+import           Control.Lens.Lens           (Lens', lens)
+import           Control.Lens.Prism          (Prism', prism)
 
-import           Flow
+import           Flow                        ((|>))
 
 --------------------------------------------------------------------------------
 

--- a/library/Language/Ninja/Env.hs
+++ b/library/Language/Ninja/Env.hs
@@ -53,12 +53,10 @@ module Language.Ninja.Env
   , scopeEnv, addEnv, askEnv
   ) where
 
-import           Control.Applicative
-import           Control.Monad
+import           Control.Applicative ((<|>))
+import           Control.Monad       ((>=>))
 
-import           Control.Lens.Iso
-
-import           Data.Maybe
+import           Control.Lens.Iso    (Iso', iso)
 
 import           Data.List.NonEmpty  (NonEmpty (..))
 import qualified Data.List.NonEmpty  as NE
@@ -69,10 +67,12 @@ import qualified Data.HashMap.Strict as HM
 import           Data.Hashable       (Hashable)
 import           GHC.Generics        (Generic)
 
-import           Data.Aeson          as Aeson
+import           Data.Aeson          (FromJSON(..), FromJSONKey(..), ToJSON(..),
+                                      ToJSONKey(..))
+import qualified Data.Aeson          as Aeson
 import qualified Data.Aeson.Types    as Aeson
 
-import           Flow
+import           Flow                ((.>))
 
 -- | A Ninja-style environment, basically a linked-list of hash tables.
 newtype Env k v

--- a/library/Language/Ninja/Pretty.hs
+++ b/library/Language/Ninja/Pretty.hs
@@ -46,9 +46,9 @@ module Language.Ninja.Pretty
 
 import qualified Control.Arrow         as Arr
 
-import           Control.Lens.Getter
+import           Control.Lens.Getter   ((^.))
 
-import           Language.Ninja.Types
+import           Language.Ninja.Types  (FileText, PBuild, PNinja, PRule)
 
 import qualified Language.Ninja.Env    as Ninja
 import qualified Language.Ninja.Types  as Ninja
@@ -63,25 +63,26 @@ import qualified Data.HashMap.Strict   as HM
 import           Data.HashSet          (HashSet)
 import qualified Data.HashSet          as HS
 
+import           Data.Text             (Text)
 import qualified Data.Text             as T
 import qualified Data.Text.Encoding    as T
 
 import qualified Data.HashMap.Strict   as HM
 
-import           Data.Char
-import           Data.Monoid
+import           Data.Char             (isSpace)
+import           Data.Monoid           ((<>))
 
-import           Flow
+import           Flow                  ((|>), (.>))
 
 -- | FIXME: doc
 prettyNinja :: PNinja -> Text
 prettyNinja ninja
-  = [ map prettyRule     (HM.toList (ninja ^. pninjaRules))
-    , map prettySingle   (HM.toList (ninja ^. pninjaSingles))
-    , map prettyMultiple (HM.toList (ninja ^. pninjaMultiples))
-    , map prettyPhony    (HM.toList (ninja ^. pninjaPhonys))
-    , map prettyDefault  (HS.toList (ninja ^. pninjaDefaults))
-    , map prettyPool     (HM.toList (ninja ^. pninjaPools))
+  = [ map prettyRule     (HM.toList (ninja ^. Ninja.pninjaRules))
+    , map prettySingle   (HM.toList (ninja ^. Ninja.pninjaSingles))
+    , map prettyMultiple (HM.toList (ninja ^. Ninja.pninjaMultiples))
+    , map prettyPhony    (HM.toList (ninja ^. Ninja.pninjaPhonys))
+    , map prettyDefault  (HS.toList (ninja ^. Ninja.pninjaDefaults))
+    , map prettyPool     (HM.toList (ninja ^. Ninja.pninjaPools))
     ] |> mconcat |> mconcat
 
 -- | FIXME: doc
@@ -95,7 +96,7 @@ prettyExpr = go .> mconcat
 -- | FIXME: doc
 prettyRule :: (Text, PRule) -> Text
 prettyRule (name, rule) = do
-  let binds = rule ^. pruleBind
+  let binds = rule ^. Ninja.pruleBind
               |> HM.toList
               |> map (Arr.second prettyExpr .> prettyBind)
               |> mconcat
@@ -114,11 +115,11 @@ prettyMultiple (outputs, build) = do
   let unwordsSet :: HashSet Text -> Text
       unwordsSet = HS.toList .> T.unwords
 
-  let ruleName  = build ^. pbuildRule
-  let normal    = build ^. pbuildDeps . pdepsNormal
-  let implicit  = build ^. pbuildDeps . pdepsImplicit
-  let orderOnly = build ^. pbuildDeps . pdepsOrderOnly
-  let binds     = build ^. pbuildBind
+  let ruleName  = build ^. Ninja.pbuildRule
+  let normal    = build ^. Ninja.pbuildDeps . Ninja.pdepsNormal
+  let implicit  = build ^. Ninja.pbuildDeps . Ninja.pdepsImplicit
+  let orderOnly = build ^. Ninja.pbuildDeps . Ninja.pdepsOrderOnly
+  let binds     = build ^. Ninja.pbuildBind
 
   mconcat
     [ "build ", T.unwords (HS.toList outputs), ": "


### PR DESCRIPTION
This updates some modules to not use any open imports, so that people reading the
code can more easily track down the origin of each imported symbol